### PR TITLE
fix read of settings

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -3,12 +3,11 @@ import { URLExt } from '@jupyterlab/coreutils';
 import { ServerConnection } from '@jupyterlab/services';
 
 export namespace Server {
-  const settings = ServerConnection.defaultSettings;
-
   export async function makeRequest(
     endpoint: string,
     request: RequestInit
   ): Promise<Response> {
+    const settings = ServerConnection.makeSettings();
     const url = URLExt.join(settings.baseUrl, endpoint);
     return await ServerConnection.makeRequest(url, request, settings);
   }


### PR DESCRIPTION
This seems to be necessary for my jupyterlab.  It needs to reread the settings when calculating the endpoints.